### PR TITLE
Add macro and geometry file for EMCal in sPHENIX calorimetry prototype3

### DIFF
--- a/Prototype3/Geometry/cemc_geoparams-0-0-4294967295-1483217839.xml
+++ b/Prototype3/Geometry/cemc_geoparams-0-0-4294967295-1483217839.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0"?>
+<root setup="2xoo" ref="null" created="2016-12-31 15:57:19" modified="2016-12-31 15:57:19" uuid="b7fe1f86-cf9b-11e6-9717-c7b4c782beef" version="3" file_version="53434">
+  <XmlKey name="PdbParameterMapContainer" cycle="1" created="2016-12-31 15:57:19">
+    <Object class="PdbParameterMapContainer">
+      <PdbParameterMapContainer version="1">
+        <PdbCalChan version="1">
+          <PHObject version="0">
+            <TObject fUniqueID="0" fBits="3000000"/>
+          </PHObject>
+        </PdbCalChan>
+        <parametermap>
+          <Version v="9"/>
+          <Int_t v="1"/>
+          <Int_t v="0"/>
+          <Object class="PdbParameterMap">
+            <PdbParameterMap version="1">
+              <PdbCalChan version="1">
+                <PHObject version="0">
+                  <TObject fUniqueID="0" fBits="3000000"/>
+                </PHObject>
+              </PdbCalChan>
+              <dparams>
+                <Version v="9"/>
+                <Int_t v="97"/>
+                <string v="assembly_spacing"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="azimuthal_tilt"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="electronics_thickness"/>
+                <Double_t v="2.540000000000000e-01"/>
+                <string v="enclosure_thickness"/>
+                <Double_t v="1.016000000000000e-01"/>
+                <string v="enclosure_x"/>
+                <Double_t v="4.064000000000000e+01"/>
+                <string v="enclosure_x_shift"/>
+                <Double_t v="-7.620000000000000e+00"/>
+                <string v="enclosure_y"/>
+                <Double_t v="3.302000000000000e+01"/>
+                <string v="enclosure_z"/>
+                <Double_t v="4.826000000000000e+01"/>
+                <string v="fiber_clading_thickness"/>
+                <Double_t v="1.500000000000000e-03"/>
+                <string v="fiber_core_diameter"/>
+                <Double_t v="4.400000000000000e-02"/>
+                <string v="polar_taper_ratio"/>
+                <Double_t v="1.000000000000000e+00"/>
+                <string v="radius"/>
+                <Double_t v="9.750000000000000e+01"/>
+                <string v="sector_map[0].rotation"/>
+                <Double_t v="-1.644427404613407e+00"/>
+                <string v="sector_map[1].rotation"/>
+                <Double_t v="-1.595340019401067e+00"/>
+                <string v="sector_map[2].rotation"/>
+                <Double_t v="-1.546252634188726e+00"/>
+                <string v="sector_map[3].rotation"/>
+                <Double_t v="-1.497165248976386e+00"/>
+                <string v="sector_tower_map[0].LightguideHeight"/>
+                <Double_t v="5.080000000000000e+00"/>
+                <string v="sector_tower_map[0].LightguideTaperRatio"/>
+                <Double_t v="5.245428296438884e-01"/>
+                <string v="sector_tower_map[0].ModuleSkinThickness"/>
+                <Double_t v="5.000000000000000e-02"/>
+                <string v="sector_tower_map[0].centralX"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[0].centralY"/>
+                <Double_t v="1.046105000000000e+02"/>
+                <string v="sector_tower_map[0].centralZ"/>
+                <Double_t v="1.033875000000000e+02"/>
+                <string v="sector_tower_map[0].pAlp1"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[0].pAlp2"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[0].pDx1"/>
+                <Double_t v="2.378218086725677e+00"/>
+                <string v="sector_tower_map[0].pDx2"/>
+                <Double_t v="2.458418435155536e+00"/>
+                <string v="sector_tower_map[0].pDx3"/>
+                <Double_t v="2.640274627738456e+00"/>
+                <string v="sector_tower_map[0].pDx4"/>
+                <Double_t v="2.729263382883311e+00"/>
+                <string v="sector_tower_map[0].pDy1"/>
+                <Double_t v="2.318947339607064e+00"/>
+                <string v="sector_tower_map[0].pDy2"/>
+                <Double_t v="2.573509695377792e+00"/>
+                <string v="sector_tower_map[0].pDz"/>
+                <Double_t v="7.630167838914158e+00"/>
+                <string v="sector_tower_map[0].pPhi"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[0].pRotationAngleX"/>
+                <Double_t v="-7.912829015461540e-01"/>
+                <string v="sector_tower_map[0].pTheta"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[1].LightguideHeight"/>
+                <Double_t v="5.080000000000000e+00"/>
+                <string v="sector_tower_map[1].LightguideTaperRatio"/>
+                <Double_t v="5.245428296438884e-01"/>
+                <string v="sector_tower_map[1].ModuleSkinThickness"/>
+                <Double_t v="5.000000000000000e-02"/>
+                <string v="sector_tower_map[1].centralX"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[1].centralY"/>
+                <Double_t v="1.046087500000000e+02"/>
+                <string v="sector_tower_map[1].centralZ"/>
+                <Double_t v="1.103915000000000e+02"/>
+                <string v="sector_tower_map[1].pAlp1"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[1].pAlp2"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[1].pDx1"/>
+                <Double_t v="2.378218086725677e+00"/>
+                <string v="sector_tower_map[1].pDx2"/>
+                <Double_t v="2.461045137721192e+00"/>
+                <string v="sector_tower_map[1].pDx3"/>
+                <Double_t v="2.637476084818038e+00"/>
+                <string v="sector_tower_map[1].pDx4"/>
+                <Double_t v="2.729263382883311e+00"/>
+                <string v="sector_tower_map[1].pDy1"/>
+                <Double_t v="2.319042006722310e+00"/>
+                <string v="sector_tower_map[1].pDy2"/>
+                <Double_t v="2.570508202209088e+00"/>
+                <string v="sector_tower_map[1].pDz"/>
+                <Double_t v="7.809818119681150e+00"/>
+                <string v="sector_tower_map[1].pPhi"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[1].pRotationAngleX"/>
+                <Double_t v="-7.584816757562671e-01"/>
+                <string v="sector_tower_map[1].pTheta"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[2].LightguideHeight"/>
+                <Double_t v="5.080000000000000e+00"/>
+                <string v="sector_tower_map[2].LightguideTaperRatio"/>
+                <Double_t v="5.245428296438884e-01"/>
+                <string v="sector_tower_map[2].ModuleSkinThickness"/>
+                <Double_t v="5.000000000000000e-02"/>
+                <string v="sector_tower_map[2].centralX"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[2].centralY"/>
+                <Double_t v="1.046070000000000e+02"/>
+                <string v="sector_tower_map[2].centralZ"/>
+                <Double_t v="1.176335000000000e+02"/>
+                <string v="sector_tower_map[2].pAlp1"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[2].pAlp2"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[2].pDx1"/>
+                <Double_t v="2.378218086725677e+00"/>
+                <string v="sector_tower_map[2].pDx2"/>
+                <Double_t v="2.463475451309975e+00"/>
+                <string v="sector_tower_map[2].pDx3"/>
+                <Double_t v="2.634873930874492e+00"/>
+                <string v="sector_tower_map[2].pDx4"/>
+                <Double_t v="2.729263382883311e+00"/>
+                <string v="sector_tower_map[2].pDy1"/>
+                <Double_t v="2.318986328524464e+00"/>
+                <string v="sector_tower_map[2].pDy2"/>
+                <Double_t v="2.567624436611617e+00"/>
+                <string v="sector_tower_map[2].pDz"/>
+                <Double_t v="8.006497939174157e+00"/>
+                <string v="sector_tower_map[2].pPhi"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[2].pRotationAngleX"/>
+                <Double_t v="-7.268549720172683e-01"/>
+                <string v="sector_tower_map[2].pTheta"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[3].LightguideHeight"/>
+                <Double_t v="5.080000000000000e+00"/>
+                <string v="sector_tower_map[3].LightguideTaperRatio"/>
+                <Double_t v="5.245428296438884e-01"/>
+                <string v="sector_tower_map[3].ModuleSkinThickness"/>
+                <Double_t v="5.000000000000000e-02"/>
+                <string v="sector_tower_map[3].centralX"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[3].centralY"/>
+                <Double_t v="1.046055000000000e+02"/>
+                <string v="sector_tower_map[3].centralZ"/>
+                <Double_t v="1.251302500000000e+02"/>
+                <string v="sector_tower_map[3].pAlp1"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[3].pAlp2"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[3].pDx1"/>
+                <Double_t v="2.378218086725677e+00"/>
+                <string v="sector_tower_map[3].pDx2"/>
+                <Double_t v="2.465758473166105e+00"/>
+                <string v="sector_tower_map[3].pDx3"/>
+                <Double_t v="2.632443617285709e+00"/>
+                <string v="sector_tower_map[3].pDx4"/>
+                <Double_t v="2.729263382883311e+00"/>
+                <string v="sector_tower_map[3].pDy1"/>
+                <Double_t v="2.318936153085868e+00"/>
+                <string v="sector_tower_map[3].pDy2"/>
+                <Double_t v="2.565600107054899e+00"/>
+                <string v="sector_tower_map[3].pDz"/>
+                <Double_t v="8.220362024418392e+00"/>
+                <string v="sector_tower_map[3].pPhi"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sector_tower_map[3].pRotationAngleX"/>
+                <Double_t v="-6.963153040001249e-01"/>
+                <string v="sector_tower_map[3].pTheta"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sidewall_outer_torr"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="sidewall_thickness"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="thickness"/>
+                <Double_t v="1.534999999999999e+01"/>
+                <string v="xpos"/>
+                <Double_t v="1.050000000000000e+02"/>
+                <string v="ypos"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="z_rotation_degree"/>
+                <Double_t v="0.000000000000000e+00"/>
+                <string v="zmax"/>
+                <Double_t v="1.360860000000000e+02"/>
+                <string v="zmin"/>
+                <Double_t v="9.137100000000001e+01"/>
+                <string v="zpos"/>
+                <Double_t v="0.000000000000000e+00"/>
+              </dparams>
+              <iparams>
+                <Version v="9"/>
+                <Int_t v="30"/>
+                <string v="azimuthal_n_sec"/>
+                <Int_t v="128"/>
+                <string v="azimuthal_seg_visible"/>
+                <Int_t v="1"/>
+                <string v="max_phi_bin_in_sec"/>
+                <Int_t v="1"/>
+                <string v="sector_map[0].id"/>
+                <Int_t v="0"/>
+                <string v="sector_map[1].id"/>
+                <Int_t v="1"/>
+                <string v="sector_map[2].id"/>
+                <Int_t v="2"/>
+                <string v="sector_map[3].id"/>
+                <Int_t v="3"/>
+                <string v="sector_map_size"/>
+                <Int_t v="4"/>
+                <string v="sector_tower_map[0].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[0].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[0].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[0].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[0].id"/>
+                <Int_t v="1"/>
+                <string v="sector_tower_map[1].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[1].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[1].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[1].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[1].id"/>
+                <Int_t v="11"/>
+                <string v="sector_tower_map[2].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[2].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[2].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[2].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[2].id"/>
+                <Int_t v="21"/>
+                <string v="sector_tower_map[3].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[3].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[3].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[3].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[3].id"/>
+                <Int_t v="31"/>
+                <string v="sector_tower_map_size"/>
+                <Int_t v="4"/>
+                <string v="virualize_fiber"/>
+                <Int_t v="1"/>
+              </iparams>
+              <cparams>
+                <Version v="9"/>
+                <Int_t v="7"/>
+                <string v="description"/>
+                <string v="sPHENIX 2017 SPACAL prototype in the default orientation"/>
+                <string v="electronics_material"/>
+                <string v="G10"/>
+                <string v="enclosure_material"/>
+                <string v="G10"/>
+                <string v="sector_tower_map[0].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[1].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[2].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[3].LightguideMaterial"/>
+                <string v="PMMA"/>
+              </cparams>
+            </PdbParameterMap>
+          </Object>
+        </parametermap>
+      </PdbParameterMapContainer>
+    </Object>
+  </XmlKey>
+  <StreamerInfos>
+    <TStreamerInfo name="PdbParameterMap" title="" v="9" classversion="1" canoptimize="true" checksum="916496646">
+      <TStreamerBase name="PdbCalChan" v="3" type="0" typename="BASE" size="24" baseversion="1" basechecksum="-1932344380"/>
+      <TStreamerSTL name="dparams" v="3" type="300" typename="map&lt;const string,double&gt;" size="48" STLtype="4" Ctype="61"/>
+      <TStreamerSTL name="iparams" v="3" type="300" typename="map&lt;const string,int&gt;" size="48" STLtype="4" Ctype="61"/>
+      <TStreamerSTL name="cparams" v="3" type="300" typename="map&lt;const string,string&gt;" size="48" STLtype="4" Ctype="61"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PdbCalChan" title="" v="9" classversion="1" canoptimize="true" checksum="-1932344380">
+      <TStreamerBase name="PHObject" title="no I/O" v="3" type="0" typename="BASE" size="24" baseversion="0" basechecksum="-179181571"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PHObject" title="" v="9" classversion="0" canoptimize="true" checksum="-179181571">
+      <TStreamerBase name="TObject" title="Basic ROOT object" v="3" type="66" typename="BASE" size="16" baseversion="1" basechecksum="-1877229523"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PdbParameterMapContainer" title="" v="9" classversion="1" canoptimize="true" checksum="-1660157473">
+      <TStreamerBase name="PdbCalChan" v="3" type="0" typename="BASE" size="24" baseversion="1" basechecksum="-1932344380"/>
+      <TStreamerSTL name="parametermap" v="3" type="300" typename="map&lt;int,PdbParameterMap*&gt;" size="48" STLtype="4" Ctype="61"/>
+    </TStreamerInfo>
+  </StreamerInfos>
+</root>

--- a/Prototype3/Geometry/cemc_geoparams-0-0-4294967295-1483238881.xml
+++ b/Prototype3/Geometry/cemc_geoparams-0-0-4294967295-1483238881.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0"?>
+<root setup="2xoo" ref="null" created="2016-12-31 21:48:01" modified="2016-12-31 21:48:01" uuid="b5e05f94-cfcc-11e6-9717-c7b4c782beef" version="3" file_version="53434">
+  <XmlKey name="PdbParameterMapContainer" cycle="1" created="2016-12-31 21:48:01">
+    <Object class="PdbParameterMapContainer">
+      <PdbParameterMapContainer version="1">
+        <PdbCalChan version="1">
+          <PHObject version="0">
+            <TObject fUniqueID="0" fBits="3000000"/>
+          </PHObject>
+        </PdbCalChan>
+        <parametermap>
+          <Version v="9"/>
+          <Int_t v="1"/>
+          <Int_t v="0"/>
+          <Object class="PdbParameterMap">
+            <PdbParameterMap version="1">
+              <PdbCalChan version="1">
+                <PHObject version="0">
+                  <TObject fUniqueID="0" fBits="3000000"/>
+                </PHObject>
+              </PdbCalChan>
+              <dparams>
+                <Version v="9"/>
+                <Int_t v="97"/>
+                <string v="assembly_spacing"/>
+                <Double_t v="0"/>
+                <string v="azimuthal_tilt"/>
+                <Double_t v="0"/>
+                <string v="electronics_thickness"/>
+                <Double_t v="0.254"/>
+                <string v="enclosure_thickness"/>
+                <Double_t v="0.10160000000000001"/>
+                <string v="enclosure_x"/>
+                <Double_t v="40.640000000000001"/>
+                <string v="enclosure_x_shift"/>
+                <Double_t v="-7.6200000000000001"/>
+                <string v="enclosure_y"/>
+                <Double_t v="33.020000000000003"/>
+                <string v="enclosure_z"/>
+                <Double_t v="48.259999999999998"/>
+                <string v="fiber_clading_thickness"/>
+                <Double_t v="0.0015"/>
+                <string v="fiber_core_diameter"/>
+                <Double_t v="0.043999999999999997"/>
+                <string v="polar_taper_ratio"/>
+                <Double_t v="1"/>
+                <string v="radius"/>
+                <Double_t v="97.5"/>
+                <string v="sector_map[0].rotation"/>
+                <Double_t v="-1.6444274046134073"/>
+                <string v="sector_map[1].rotation"/>
+                <Double_t v="-1.5953400194010667"/>
+                <string v="sector_map[2].rotation"/>
+                <Double_t v="-1.5462526341887264"/>
+                <string v="sector_map[3].rotation"/>
+                <Double_t v="-1.4971652489763858"/>
+                <string v="sector_tower_map[0].LightguideHeight"/>
+                <Double_t v="5.0800000000000001"/>
+                <string v="sector_tower_map[0].LightguideTaperRatio"/>
+                <Double_t v="0.52454282964388843"/>
+                <string v="sector_tower_map[0].ModuleSkinThickness"/>
+                <Double_t v="0.050000000000000003"/>
+                <string v="sector_tower_map[0].centralX"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[0].centralY"/>
+                <Double_t v="104.6105"/>
+                <string v="sector_tower_map[0].centralZ"/>
+                <Double_t v="103.3875"/>
+                <string v="sector_tower_map[0].pAlp1"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[0].pAlp2"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[0].pDx1"/>
+                <Double_t v="2.3782180867256768"/>
+                <string v="sector_tower_map[0].pDx2"/>
+                <Double_t v="2.458418435155536"/>
+                <string v="sector_tower_map[0].pDx3"/>
+                <Double_t v="2.6402746277384557"/>
+                <string v="sector_tower_map[0].pDx4"/>
+                <Double_t v="2.7292633828833108"/>
+                <string v="sector_tower_map[0].pDy1"/>
+                <Double_t v="2.3189473396070639"/>
+                <string v="sector_tower_map[0].pDy2"/>
+                <Double_t v="2.5735096953777923"/>
+                <string v="sector_tower_map[0].pDz"/>
+                <Double_t v="7.6301678389141578"/>
+                <string v="sector_tower_map[0].pPhi"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[0].pRotationAngleX"/>
+                <Double_t v="-0.79128290154615399"/>
+                <string v="sector_tower_map[0].pTheta"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[1].LightguideHeight"/>
+                <Double_t v="5.0800000000000001"/>
+                <string v="sector_tower_map[1].LightguideTaperRatio"/>
+                <Double_t v="0.52454282964388843"/>
+                <string v="sector_tower_map[1].ModuleSkinThickness"/>
+                <Double_t v="0.050000000000000003"/>
+                <string v="sector_tower_map[1].centralX"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[1].centralY"/>
+                <Double_t v="104.60874999999999"/>
+                <string v="sector_tower_map[1].centralZ"/>
+                <Double_t v="110.39150000000001"/>
+                <string v="sector_tower_map[1].pAlp1"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[1].pAlp2"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[1].pDx1"/>
+                <Double_t v="2.3782180867256768"/>
+                <string v="sector_tower_map[1].pDx2"/>
+                <Double_t v="2.4610451377211917"/>
+                <string v="sector_tower_map[1].pDx3"/>
+                <Double_t v="2.6374760848180383"/>
+                <string v="sector_tower_map[1].pDx4"/>
+                <Double_t v="2.7292633828833108"/>
+                <string v="sector_tower_map[1].pDy1"/>
+                <Double_t v="2.3190420067223099"/>
+                <string v="sector_tower_map[1].pDy2"/>
+                <Double_t v="2.5705082022090879"/>
+                <string v="sector_tower_map[1].pDz"/>
+                <Double_t v="7.8098181196811503"/>
+                <string v="sector_tower_map[1].pPhi"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[1].pRotationAngleX"/>
+                <Double_t v="-0.75848167575626713"/>
+                <string v="sector_tower_map[1].pTheta"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[2].LightguideHeight"/>
+                <Double_t v="5.0800000000000001"/>
+                <string v="sector_tower_map[2].LightguideTaperRatio"/>
+                <Double_t v="0.52454282964388843"/>
+                <string v="sector_tower_map[2].ModuleSkinThickness"/>
+                <Double_t v="0.050000000000000003"/>
+                <string v="sector_tower_map[2].centralX"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[2].centralY"/>
+                <Double_t v="104.607"/>
+                <string v="sector_tower_map[2].centralZ"/>
+                <Double_t v="117.6335"/>
+                <string v="sector_tower_map[2].pAlp1"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[2].pAlp2"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[2].pDx1"/>
+                <Double_t v="2.3782180867256768"/>
+                <string v="sector_tower_map[2].pDx2"/>
+                <Double_t v="2.463475451309975"/>
+                <string v="sector_tower_map[2].pDx3"/>
+                <Double_t v="2.6348739308744924"/>
+                <string v="sector_tower_map[2].pDx4"/>
+                <Double_t v="2.7292633828833108"/>
+                <string v="sector_tower_map[2].pDy1"/>
+                <Double_t v="2.3189863285244643"/>
+                <string v="sector_tower_map[2].pDy2"/>
+                <Double_t v="2.5676244366116174"/>
+                <string v="sector_tower_map[2].pDz"/>
+                <Double_t v="8.0064979391741566"/>
+                <string v="sector_tower_map[2].pPhi"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[2].pRotationAngleX"/>
+                <Double_t v="-0.72685497201726834"/>
+                <string v="sector_tower_map[2].pTheta"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[3].LightguideHeight"/>
+                <Double_t v="5.0800000000000001"/>
+                <string v="sector_tower_map[3].LightguideTaperRatio"/>
+                <Double_t v="0.52454282964388843"/>
+                <string v="sector_tower_map[3].ModuleSkinThickness"/>
+                <Double_t v="0.050000000000000003"/>
+                <string v="sector_tower_map[3].centralX"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[3].centralY"/>
+                <Double_t v="104.60549999999999"/>
+                <string v="sector_tower_map[3].centralZ"/>
+                <Double_t v="125.13025"/>
+                <string v="sector_tower_map[3].pAlp1"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[3].pAlp2"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[3].pDx1"/>
+                <Double_t v="2.3782180867256768"/>
+                <string v="sector_tower_map[3].pDx2"/>
+                <Double_t v="2.4657584731661051"/>
+                <string v="sector_tower_map[3].pDx3"/>
+                <Double_t v="2.6324436172857086"/>
+                <string v="sector_tower_map[3].pDx4"/>
+                <Double_t v="2.7292633828833108"/>
+                <string v="sector_tower_map[3].pDy1"/>
+                <Double_t v="2.3189361530858683"/>
+                <string v="sector_tower_map[3].pDy2"/>
+                <Double_t v="2.565600107054899"/>
+                <string v="sector_tower_map[3].pDz"/>
+                <Double_t v="8.2203620244183924"/>
+                <string v="sector_tower_map[3].pPhi"/>
+                <Double_t v="0"/>
+                <string v="sector_tower_map[3].pRotationAngleX"/>
+                <Double_t v="-0.69631530400012487"/>
+                <string v="sector_tower_map[3].pTheta"/>
+                <Double_t v="0"/>
+                <string v="sidewall_outer_torr"/>
+                <Double_t v="0"/>
+                <string v="sidewall_thickness"/>
+                <Double_t v="0"/>
+                <string v="thickness"/>
+                <Double_t v="15.349999999999994"/>
+                <string v="xpos"/>
+                <Double_t v="105"/>
+                <string v="ypos"/>
+                <Double_t v="0"/>
+                <string v="z_rotation_degree"/>
+                <Double_t v="0"/>
+                <string v="zmax"/>
+                <Double_t v="136.08599999999998"/>
+                <string v="zmin"/>
+                <Double_t v="91.371000000000009"/>
+                <string v="zpos"/>
+                <Double_t v="0"/>
+              </dparams>
+              <iparams>
+                <Version v="9"/>
+                <Int_t v="30"/>
+                <string v="azimuthal_n_sec"/>
+                <Int_t v="128"/>
+                <string v="azimuthal_seg_visible"/>
+                <Int_t v="1"/>
+                <string v="max_phi_bin_in_sec"/>
+                <Int_t v="1"/>
+                <string v="sector_map[0].id"/>
+                <Int_t v="0"/>
+                <string v="sector_map[1].id"/>
+                <Int_t v="1"/>
+                <string v="sector_map[2].id"/>
+                <Int_t v="2"/>
+                <string v="sector_map[3].id"/>
+                <Int_t v="3"/>
+                <string v="sector_map_size"/>
+                <Int_t v="4"/>
+                <string v="sector_tower_map[0].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[0].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[0].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[0].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[0].id"/>
+                <Int_t v="1"/>
+                <string v="sector_tower_map[1].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[1].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[1].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[1].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[1].id"/>
+                <Int_t v="11"/>
+                <string v="sector_tower_map[2].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[2].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[2].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[2].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[2].id"/>
+                <Int_t v="21"/>
+                <string v="sector_tower_map[3].NFiberX"/>
+                <Int_t v="94"/>
+                <string v="sector_tower_map[3].NFiberY"/>
+                <Int_t v="52"/>
+                <string v="sector_tower_map[3].NSubtowerX"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[3].NSubtowerY"/>
+                <Int_t v="2"/>
+                <string v="sector_tower_map[3].id"/>
+                <Int_t v="31"/>
+                <string v="sector_tower_map_size"/>
+                <Int_t v="4"/>
+                <string v="virualize_fiber"/>
+                <Int_t v="1"/>
+              </iparams>
+              <cparams>
+                <Version v="9"/>
+                <Int_t v="7"/>
+                <string v="description"/>
+                <string v="sPHENIX 2017 SPACAL prototype in the default orientation"/>
+                <string v="electronics_material"/>
+                <string v="G10"/>
+                <string v="enclosure_material"/>
+                <string v="G10"/>
+                <string v="sector_tower_map[0].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[1].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[2].LightguideMaterial"/>
+                <string v="PMMA"/>
+                <string v="sector_tower_map[3].LightguideMaterial"/>
+                <string v="PMMA"/>
+              </cparams>
+            </PdbParameterMap>
+          </Object>
+        </parametermap>
+      </PdbParameterMapContainer>
+    </Object>
+  </XmlKey>
+  <StreamerInfos>
+    <TStreamerInfo name="PdbParameterMap" title="" v="9" classversion="1" canoptimize="true" checksum="916496646">
+      <TStreamerBase name="PdbCalChan" v="3" type="0" typename="BASE" size="24" baseversion="1" basechecksum="-1932344380"/>
+      <TStreamerSTL name="dparams" v="3" type="300" typename="map&lt;const string,double&gt;" size="48" STLtype="4" Ctype="61"/>
+      <TStreamerSTL name="iparams" v="3" type="300" typename="map&lt;const string,int&gt;" size="48" STLtype="4" Ctype="61"/>
+      <TStreamerSTL name="cparams" v="3" type="300" typename="map&lt;const string,string&gt;" size="48" STLtype="4" Ctype="61"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PdbCalChan" title="" v="9" classversion="1" canoptimize="true" checksum="-1932344380">
+      <TStreamerBase name="PHObject" title="no I/O" v="3" type="0" typename="BASE" size="24" baseversion="0" basechecksum="-179181571"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PHObject" title="" v="9" classversion="0" canoptimize="true" checksum="-179181571">
+      <TStreamerBase name="TObject" title="Basic ROOT object" v="3" type="66" typename="BASE" size="16" baseversion="1" basechecksum="-1877229523"/>
+    </TStreamerInfo>
+    <TStreamerInfo name="PdbParameterMapContainer" title="" v="9" classversion="1" canoptimize="true" checksum="-1660157473">
+      <TStreamerBase name="PdbCalChan" v="3" type="0" typename="BASE" size="24" baseversion="1" basechecksum="-1932344380"/>
+      <TStreamerSTL name="parametermap" v="3" type="300" typename="map&lt;int,PdbParameterMap*&gt;" size="48" STLtype="4" Ctype="61"/>
+    </TStreamerInfo>
+  </StreamerInfos>
+</root>

--- a/Prototype3/macros/Construct_CEMC_Param_2017.C
+++ b/Prototype3/macros/Construct_CEMC_Param_2017.C
@@ -27,7 +27,7 @@ Construct_CEMC_Param_2017()
   param->set_int_param("virualize_fiber", 1);
 
   //general placement
-  param->set_double_param("xpos", (116.77 + 137.0) * .5 - 26.5 - 10.2);
+  param->set_double_param("xpos", 98+7);
   param->set_double_param("ypos", 0);
   param->set_double_param("zpos", 0);
   param->set_double_param("z_rotation_degree", 0);
@@ -39,16 +39,16 @@ Construct_CEMC_Param_2017()
   param->set_double_param("enclosure_z", 19 * inch_to_cm);
   param->set_double_param("enclosure_thickness", 0.04 * inch_to_cm);
   param->set_string_param("enclosure_material", "G10");
-  param->set_double_param("enclosure_x_shift", -2 * inch_to_cm);
+  param->set_double_param("enclosure_x_shift", -3 * inch_to_cm);
 
   param->set_double_param("electronics_thickness", 0.1 * inch_to_cm);
   param->set_string_param("electronics_material", "G10");
 
   // construct 4x8 modules
-//  const int ny = 4;
-//  const int nx = 4;
-  const int ny = 1;
-  const int nx = 1;
+  const int ny = 4;
+  const int nx = 4;
+//  const int ny = 1;
+//  const int nx = 1;
 //  const int nx = 1;
 
   // Sean Stoll:
@@ -65,8 +65,8 @@ Construct_CEMC_Param_2017()
    * */
 
   // 2016 THP new screen:
-  const int NFiberX = 30;
-  const int NFiberY = 52 * 2;
+  const int NFiberY = 52;
+  const int NFiberX = 47 * 2;
 //  const double hole_edge_to_screen_edge = 0;
   const double fiber_diameter = 0.047;
 //
@@ -78,7 +78,7 @@ Construct_CEMC_Param_2017()
   const double assembly_spacing_x = 0.33 / 10 / 2.;
   const double assembly_spacing_y = 0.1 / 10 / 2.;
 
-  const double radius = 95;
+  const double radius = 97.5;
   const double thickness = 111.85 + 1 - radius;
   const double zmin = (963.71 - 50) / 10;
   const double zmax = (1330.86 + 30) / 10;

--- a/Prototype3/macros/Construct_CEMC_Param_2017.C
+++ b/Prototype3/macros/Construct_CEMC_Param_2017.C
@@ -1,0 +1,266 @@
+// $$Id: $$
+#include <TVector2.h>
+
+// to load tower map from Richie
+class four_corner
+{
+public:
+  TVector2 p1, p2, p3, p4;
+};
+
+void
+Construct_CEMC_Param_2017()
+{
+  cout << "Construct_CEMC_Param() - Entry" << endl;
+
+  gSystem->Load("libg4detectors.so");
+
+  PHG4Parameters * param = new PHG4Parameters("CEMC_0");
+
+  param->set_string_param("description",
+      "sPHENIX 2017 SPACAL prototype in the default orientation");
+
+  const double inch_to_cm = 2.54;
+
+  // visual switches
+  param->set_int_param("azimuthal_seg_visible", 1);
+  param->set_int_param("virualize_fiber", 1);
+
+  //general placement
+  param->set_double_param("xpos", (116.77 + 137.0) * .5 - 26.5 - 10.2);
+  param->set_double_param("ypos", 0);
+  param->set_double_param("zpos", 0);
+  param->set_double_param("z_rotation_degree", 0);
+
+  //enclosure parameters
+  // 13 inch box with 40mil G10 cover plates
+  param->set_double_param("enclosure_x", 16 * inch_to_cm);
+  param->set_double_param("enclosure_y", 13 * inch_to_cm);
+  param->set_double_param("enclosure_z", 19 * inch_to_cm);
+  param->set_double_param("enclosure_thickness", 0.04 * inch_to_cm);
+  param->set_string_param("enclosure_material", "G10");
+  param->set_double_param("enclosure_x_shift", -2 * inch_to_cm);
+
+  param->set_double_param("electronics_thickness", 0.1 * inch_to_cm);
+  param->set_string_param("electronics_material", "G10");
+
+  // construct 4x8 modules
+//  const int ny = 4;
+//  const int nx = 4;
+  const int ny = 1;
+  const int nx = 1;
+//  const int nx = 1;
+
+  // Sean Stoll:
+  // the avg thickness is about ~  24.02mm at the thin end and 26.92mm at the thick end
+  /*
+   height(mm)  width(mm) length(mm)  density (g/cc)
+   UIUC  25.6  53.4  139.2 9.43
+   THP   25.4  53.6  138.0 9.65
+   ALL   25.5  53.5  138.6 9.53
+
+   side gap    0.1 mm  gap between adjacent modules in row
+   stack gap   0.33  mm  gap between stacked rows of modules
+   pcb thickness:    1.75mm
+   * */
+
+  // 2016 THP new screen:
+  const int NFiberX = 30;
+  const int NFiberY = 52 * 2;
+//  const double hole_edge_to_screen_edge = 0;
+  const double fiber_diameter = 0.047;
+//
+  const double ModuleSkinThickness = 0.05; // 20 mil
+  const double fiber_clading_thickness = 0.003 / 2;
+  const double fiber_core_diameter = fiber_diameter
+      - fiber_clading_thickness * 2;
+
+  const double assembly_spacing_x = 0.33 / 10 / 2.;
+  const double assembly_spacing_y = 0.1 / 10 / 2.;
+
+  const double radius = 95;
+  const double thickness = 111.85 + 1 - radius;
+  const double zmin = (963.71 - 50) / 10;
+  const double zmax = (1330.86 + 30) / 10;
+//  double zmin = -0;
+  const int azimuthal_n_sec = 256 / 2;
+  const int max_phi_bin_in_sec = 1;
+
+  param->set_double_param("fiber_clading_thickness", fiber_clading_thickness);
+  param->set_double_param("fiber_core_diameter", fiber_core_diameter);
+  param->set_double_param("assembly_spacing", 0); // used for segment wall assembly, not used here in prototyes
+  param->set_double_param("radius", radius);
+  param->set_double_param("thickness", thickness);
+  param->set_double_param("zmin", zmin);
+  param->set_double_param("zmax", zmax);
+  param->set_int_param("azimuthal_n_sec", azimuthal_n_sec);
+  param->set_int_param("max_phi_bin_in_sec", max_phi_bin_in_sec);
+
+//  sector_map
+  param->set_int_param("sector_map_size", nx);
+  for (int sec = 0; sec < nx; ++sec)
+    {
+      const double rot = 2 * TMath::Pi() / (double) (azimuthal_n_sec)
+          * ((double) (sec) - (nx - 1.) / 2) - TMath::Pi() / 2.;
+
+      stringstream prefix;
+      prefix << "sector_map";
+      prefix << "[" << sec << "]" << ".";
+
+//      sector_map[sec] = rot;
+
+      param->set_int_param(prefix.str() + "id", sec);
+      param->set_double_param(prefix.str() + "rotation", rot);
+    }
+
+  param->set_double_param("azimuthal_tilt", 0);
+  param->set_double_param("polar_taper_ratio", 1);
+  param->set_double_param("sidewall_thickness", 0);
+  param->set_double_param("sidewall_outer_torr", 0);
+
+//  sector_tower_map
+//
+
+  four_corner b1, b2, b3, b4;
+  four_corner blocks[10];
+
+  b1.p1.Set(1069.17 / 10, 1118.50 / 10); // from Richie's drawing in mm
+  b2.p1.Set(1142.89 / 10, 1118.50 / 10); // from Richie's drawing in mm
+  b3.p1.Set(1219.07 / 10, 1118.50 / 10); // from Richie's drawing in mm
+  b4.p1.Set(1297.88 / 10, 1118.50 / 10); // from Richie's drawing in mm
+
+  b1.p2.Set(1105.85 / 10, 1082.25 / 10); // from Richie's drawing in mm
+  b2.p2.Set(1178.32 / 10, 1081.11 / 10); // from Richie's drawing in mm
+  b3.p2.Set(1253.26 / 10, 1080.05 / 10); // from Richie's drawing in mm
+  b4.p2.Set(1330.86 / 10, 1079.06 / 10); // from Richie's drawing in mm
+
+  b1.p3.Set(963.71 / 10, 1008.17 / 10); // from Richie's drawing in mm
+  b2.p3.Set(1031.24 / 10, 1009.24 / 10); // from Richie's drawing in mm
+  b3.p3.Set(1101.06 / 10, 1010.23 / 10); // from Richie's drawing in mm
+  b4.p3.Set(1173.33 / 10, 1011.16 / 10); // from Richie's drawing in mm
+
+  b1.p4.Set(996.77 / 10, 975.50 / 10); // from Richie's drawing in mm
+  b2.p4.Set(1063.21 / 10, 975.50 / 10); // from Richie's drawing in mm
+  b3.p4.Set(1131.95 / 10, 975.50 / 10); // from Richie's drawing in mm
+  b4.p4.Set(1203.14 / 10, 975.50 / 10); // from Richie's drawing in mm
+
+  four_corner b, b_rotated;
+  blocks[0] = b1;
+  blocks[1] = b2;
+  blocks[2] = b3;
+  blocks[3] = b4;
+  const double half_block_phi = 2 * TMath::Pi() / (double) (azimuthal_n_sec)
+      / 2;
+
+  param->set_int_param("sector_tower_map_size", ny);
+  for (int y = 0; y < ny; y++)
+    {
+
+      stringstream prefix;
+      prefix << "sector_tower_map";
+      prefix << "[" << y << "]" << ".";
+//
+
+      //use conform tower ID convension as defined in PHG4CylinderGeom_Spacalv3::get_tower_z_phi_ID()
+      param->set_int_param(prefix.str() + "id", y * 10 + 1);
+
+      b = blocks[y];
+
+      cout << "Construct_CEMC_Param_2017() - block " << prefix.str() << endl;
+      TVector2 c12 = 0.5 * (b.p1 + b.p2);
+      TVector2 c34 = 0.5 * (b.p3 + b.p4);
+      TVector2 center = 0.5 * (c12 + c34);
+      TVector2 center_line_vec = c12 - c34;
+      double pRotationAngleX = -center_line_vec.Phi();
+
+      b_rotated = b;
+      TVector2 c12_rotated = c12;
+      TVector2 c34_rotated = c34;
+
+      b_rotated.p1 -= center;
+      b_rotated.p2 -= center;
+      b_rotated.p3 -= center;
+      b_rotated.p4 -= center;
+      c12_rotated -= center;
+      c34_rotated -= center;
+
+      b_rotated.p1 = b_rotated.p1.Rotate(pRotationAngleX);
+      b_rotated.p2 = b_rotated.p2.Rotate(pRotationAngleX);
+      b_rotated.p3 = b_rotated.p3.Rotate(pRotationAngleX);
+      b_rotated.p4 = b_rotated.p4.Rotate(pRotationAngleX);
+      c12_rotated = c12_rotated.Rotate(pRotationAngleX);
+      c34_rotated = c34_rotated.Rotate(pRotationAngleX);
+
+      cout << "Construct_CEMC_Param_2017() - block " << y
+          << " four corner after rotation to along z axis by "
+          << pRotationAngleX << endl;
+      cout << "\tp1 = " << b_rotated.p1.X() << ",\t" << b_rotated.p1.Y()
+          << endl;
+      cout << "\tp2 = " << b_rotated.p2.X() << ",\t" << b_rotated.p2.Y()
+          << endl;
+      cout << "\tp3 = " << b_rotated.p3.X() << ",\t" << b_rotated.p3.Y()
+          << endl;
+      cout << "\tp4 = " << b_rotated.p4.X() << ",\t" << b_rotated.p4.Y()
+          << endl;
+      cout << "\tc12 = " << c12_rotated.X() << ",\t" << c12_rotated.Y() << endl;
+      cout << "\tc34 = " << c34_rotated.X() << ",\t" << c34_rotated.Y() << endl;
+
+      param->set_double_param(prefix.str() + "pDz", c12_rotated.X());
+      param->set_double_param(prefix.str() + "pTheta", 0.);
+      param->set_double_param(prefix.str() + "pPhi", 0.);
+      param->set_double_param(prefix.str() + "pAlp1", 0.);
+      param->set_double_param(prefix.str() + "pAlp2", 0.);
+
+      param->set_double_param(prefix.str() + "pDy1",
+          0.5 * (b_rotated.p3.Y() - b_rotated.p4.Y()) - assembly_spacing_y);
+      param->set_double_param(prefix.str() + "pDx1",
+          b.p4.Y() * tan(half_block_phi) - assembly_spacing_x);
+      param->set_double_param(prefix.str() + "pDx2",
+          b.p3.Y() * tan(half_block_phi) - assembly_spacing_x);
+
+      param->set_double_param(prefix.str() + "pDy2",
+          0.5 * (b_rotated.p1.Y() - b_rotated.p2.Y()) - assembly_spacing_y);
+      param->set_double_param(prefix.str() + "pDx3",
+          b.p2.Y() * tan(half_block_phi) - assembly_spacing_x);
+      param->set_double_param(prefix.str() + "pDx4",
+          b.p1.Y() * tan(half_block_phi) - assembly_spacing_x);
+//
+      param->set_double_param(prefix.str() + "centralX", 0);
+      param->set_double_param(prefix.str() + "centralY", center.Y());
+      param->set_double_param(prefix.str() + "centralZ", center.X());
+//
+
+      param->set_double_param(prefix.str() + "pRotationAngleX",
+          pRotationAngleX);
+      param->set_double_param(prefix.str() + "ModuleSkinThickness",
+          ModuleSkinThickness);
+      param->set_int_param(prefix.str() + "NFiberX", NFiberX); // azimuthal / narrow direction
+      param->set_int_param(prefix.str() + "NFiberY", NFiberY); // polar / wide direction
+//
+      param->set_int_param(prefix.str() + "NSubtowerX", 2);
+      param->set_int_param(prefix.str() + "NSubtowerY", 2);
+//
+      param->set_double_param(prefix.str() + "LightguideHeight",
+          2 * inch_to_cm);
+      param->set_double_param(prefix.str() + "LightguideTaperRatio",
+          0.545 / 1.039);
+      param->set_string_param(prefix.str() + "LightguideMaterial", "PMMA");
+    }
+
+  // storage
+  param->Print();
+
+  gSystem->mkdir("./test_geom/");
+
+  PdbParameterMapContainer * paramcontainer = new PdbParameterMapContainer();
+
+  PdbParameterMap *myparm = new PdbParameterMap();
+  param->CopyToPdbParameterMap(myparm);
+  paramcontainer->AddPdbParameterMap(0, myparm);
+
+  paramcontainer->WriteToFile("CEMC", "root", "./test_geom/");
+
+  paramcontainer->WriteToFile("CEMC", "xml", "./test_geom/");
+
+}
+

--- a/Prototype3/macros/Construct_CEMC_Param_2017.C
+++ b/Prototype3/macros/Construct_CEMC_Param_2017.C
@@ -248,7 +248,7 @@ Construct_CEMC_Param_2017()
     }
 
   // storage
-  param->Print();
+//  param->Print();
 
   gSystem->mkdir("./test_geom/");
 
@@ -256,6 +256,7 @@ Construct_CEMC_Param_2017()
 
   PdbParameterMap *myparm = new PdbParameterMap();
   param->CopyToPdbParameterMap(myparm);
+  myparm->print();
   paramcontainer->AddPdbParameterMap(0, myparm);
 
   paramcontainer->WriteToFile("CEMC", "root", "./test_geom/");


### PR DESCRIPTION
Based on mechanical drawing from Richard Ruggiero <ruggiero@bnl.gov> and imported to Geant4: 

## Source mechanical files

Block dimension: 
![image](https://cloud.githubusercontent.com/assets/7947083/21613406/1600d3a4-d1a3-11e6-9d8f-3122d470bbcf.png)
Block layout:
![image](https://cloud.githubusercontent.com/assets/7947083/21613664/298d381c-d1a4-11e6-92e8-ec67942a4304.png)
Typical screen:
![image](https://cloud.githubusercontent.com/assets/7947083/21613692/4bded722-d1a4-11e6-8123-02a800596ecf.png)

## Import to Geant4:

Block layout:
![prototypethree6](https://cloud.githubusercontent.com/assets/7947083/21613869/23682360-d1a5-11e6-85f2-eafab988c778.png)
![prototypethree7](https://cloud.githubusercontent.com/assets/7947083/21613870/25bd32ea-d1a5-11e6-91c0-5f260b88d6da.png)
Screen layout at center point of the prototype:
![prototypethree3](https://cloud.githubusercontent.com/assets/7947083/21613876/305bdd50-d1a5-11e6-84f1-33f94fcb1285.png)
Three calorimeter together (top view):
![prototypethree8](https://cloud.githubusercontent.com/assets/7947083/21613893/41f0e452-d1a5-11e6-8cfe-abf7e8a2d0b9.png)


