### PR TITLE
Add MDC2 JS pythia8 configs

### DIFF
--- a/Generators/JetStructure_TG/phpythia8_15GeV_JS_MDC2.cfg
+++ b/Generators/JetStructure_TG/phpythia8_15GeV_JS_MDC2.cfg
@@ -1,0 +1,39 @@
+! sPHENIX HF TG MD1	Pythia8 Tune
+! See discussions at https://indico.bnl.gov/event/10309/
+
+! Beam settings
+Beams:idA = 2212   ! first beam, p = 2212, pbar = -2212
+Beams:idB = 2212   ! second beam, p = 2212, pbar = -2212
+Beams:eCM = 200.   ! CM energy of collision
+
+! Settings related to output in init(), next() and stat()
+Init:showChangedSettings = on
+#Next:numberCount = 0          ! print message every n events
+Next:numberShowInfo = 1            ! print event information n times
+#Next:numberShowProcess = 1         ! print process record n times
+#Next:numberShowEvent = 1           ! print event record n times
+
+! PDF
+# PDF:useLHAPDF = on
+# PDF:LHAPDFset = CT10.LHgrid
+#PDF:pSet = 7 ! CTEQ6L, NLO alpha_s(M_Z) = 0.1180. 
+PDF:pSet = 13 ! NNPDF2.3 QCD+QED LO, NLO alpha_s(M_Z) = 0.130. 
+
+! Process
+#HardQCD:hardccbar = on
+# HardQCD:hardbbbar = on
+HardQCD:all = on
+# Charmonium:all = on
+# Bottomonium:all = on
+# SoftQCD:nonDiffractive = on
+#SoftQCD:inelastic = on
+
+! Cuts
+#PhaseSpace:pTHatMin = 25.0
+PhaseSpace:pTHatMin = 7.0
+ParticleDecays:limitCylinder = on
+ParticleDecays:xyMax = 0.001
+ParticleDecays:zMax = 0.001
+
+ColourReconnection:mode = 2
+TimeShower:alphaSvalue = 0.18

--- a/Generators/JetStructure_TG/phpythia8_30GeV_JS_MDC2.cfg
+++ b/Generators/JetStructure_TG/phpythia8_30GeV_JS_MDC2.cfg
@@ -1,0 +1,39 @@
+! sPHENIX HF TG MD1	Pythia8 Tune
+! See discussions at https://indico.bnl.gov/event/10309/
+
+! Beam settings
+Beams:idA = 2212   ! first beam, p = 2212, pbar = -2212
+Beams:idB = 2212   ! second beam, p = 2212, pbar = -2212
+Beams:eCM = 200.   ! CM energy of collision
+
+! Settings related to output in init(), next() and stat()
+Init:showChangedSettings = on
+#Next:numberCount = 0          ! print message every n events
+Next:numberShowInfo = 1            ! print event information n times
+#Next:numberShowProcess = 1         ! print process record n times
+#Next:numberShowEvent = 1           ! print event record n times
+
+! PDF
+# PDF:useLHAPDF = on
+# PDF:LHAPDFset = CT10.LHgrid
+#PDF:pSet = 7 ! CTEQ6L, NLO alpha_s(M_Z) = 0.1180. 
+PDF:pSet = 13 ! NNPDF2.3 QCD+QED LO, NLO alpha_s(M_Z) = 0.130. 
+
+! Process
+#HardQCD:hardccbar = on
+# HardQCD:hardbbbar = on
+HardQCD:all = on
+# Charmonium:all = on
+# Bottomonium:all = on
+# SoftQCD:nonDiffractive = on
+#SoftQCD:inelastic = on
+
+! Cuts
+#PhaseSpace:pTHatMin = 25.0
+PhaseSpace:pTHatMin = 25.0
+ParticleDecays:limitCylinder = on
+ParticleDecays:xyMax = 0.001
+ParticleDecays:zMax = 0.001
+
+ColourReconnection:mode = 2
+TimeShower:alphaSvalue = 0.18

--- a/Generators/JetStructure_TG/phpythia8_JS_GJ_MDC2.cfg
+++ b/Generators/JetStructure_TG/phpythia8_JS_GJ_MDC2.cfg
@@ -1,0 +1,40 @@
+! sPHENIX HF TG MD1	Pythia8 Tune
+! See discussions at https://indico.bnl.gov/event/10309/
+
+! Beam settings
+Beams:idA = 2212   ! first beam, p = 2212, pbar = -2212
+Beams:idB = 2212   ! second beam, p = 2212, pbar = -2212
+Beams:eCM = 200.   ! CM energy of collision
+
+! Settings related to output in init(), next() and stat()
+Init:showChangedSettings = on
+#Next:numberCount = 0          ! print message every n events
+Next:numberShowInfo = 1            ! print event information n times
+#Next:numberShowProcess = 1         ! print process record n times
+#Next:numberShowEvent = 1           ! print event record n times
+
+! PDF
+# PDF:useLHAPDF = on
+# PDF:LHAPDFset = CT10.LHgrid
+#PDF:pSet = 7 ! CTEQ6L, NLO alpha_s(M_Z) = 0.1180. 
+PDF:pSet = 13 ! NNPDF2.3 QCD+QED LO, NLO alpha_s(M_Z) = 0.130. 
+
+! Process
+#HardQCD:hardccbar = on
+# HardQCD:hardbbbar = on
+#HardQCD:all = on
+PromptPhoton:all = on
+# Charmonium:all = on
+# Bottomonium:all = on
+# SoftQCD:nonDiffractive = on
+#SoftQCD:inelastic = on
+
+! Cuts
+#PhaseSpace:pTHatMin = 25.0
+PhaseSpace:pTHatMin = 25.0
+ParticleDecays:limitCylinder = on
+ParticleDecays:xyMax = 0.1
+ParticleDecays:zMax = 0.1
+
+ColourReconnection:mode = 2
+TimeShower:alphaSvalue = 0.18


### PR DESCRIPTION
This PR finally copies the MDC2 pythia8 configs from the jet structure TG to the calibrations repo. For clarity I renamed phpythia8_JS_MDC2.cfg to phpythia8_30GeV_JS_MDC2.cfg