### PR TITLE
Tpc padplane

### DIFF
--- a/TPC/Mapping/MapCDBTTreeTPC.C
+++ b/TPC/Mapping/MapCDBTTreeTPC.C
@@ -1,0 +1,64 @@
+#include <cdbobjects/CDBTTree.h>
+#include <tpc/TpcMap.h>
+
+R__LOAD_LIBRARY(libcdbobjects.so)
+R__LOAD_LIBRARY(libtpc.so)
+
+
+void MapCDBTTreeTPC(const std::string &fname = "./PadPlane/TPCPadPlaneCDBTTree.root")
+{
+  TpcMap M;
+  // To use the latest CSV files the path should be directly 
+  // from the default CDBTTree directory used in TpcMap to files, 
+  // otherwise the default CSV Files are used 
+  M.setMapNames("../../../../../../../../../../../sphenix/user/shulga/Work/TPCPadPlaneMapping/macros/calibrations/tpc/PadPlane/AutoPad-R1-RevA.sch.ChannelMapping.csv", 
+                "../../../../../../../../../../../sphenix/user/shulga/Work/TPCPadPlaneMapping/macros/calibrations/tpc/PadPlane/AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv", 
+                "../../../../../../../../../../../sphenix/user/shulga/Work/TPCPadPlaneMapping/macros/calibrations/tpc/PadPlane/AutoPad-R3-RevA.sch.ChannelMapping.csv");
+
+
+  CDBTTree *cdbttree = new CDBTTree(fname);
+
+  int Nfee = 26;
+  int Nch = 256;
+  for(int f=0;f<Nfee;f++){
+    for(int ch=0;ch<Nch;ch++){
+      int layer = M.getLayer(f, ch);
+      int padN = M.getPad(f, ch);
+      double padR = M.getR(f, ch);
+      if (f==5 && ch==30){std::cout<<"layer="<<layer<<" padR="<<padR<<std::endl;}
+      double padPhi = M.getPhi(f, ch);
+      int mod = 0;
+      if(f>5) mod = 1;
+      if(f>15) mod =2;
+      unsigned int key = 256 * (f) + ch;
+      string varname = "layer";// + to_string(key);
+      cdbttree->SetIntValue(key,varname,layer);
+      varname = "fee";// + to_string(key);
+      cdbttree->SetIntValue(key,varname,f);
+      varname = "ch";// + to_string(key);
+      cdbttree->SetIntValue(key,varname,ch);
+      varname = "R";// + to_string(key);
+      cdbttree->SetDoubleValue(key,varname,padR);
+      varname = "phi";// + to_string(key);
+      cdbttree->SetDoubleValue(key,varname,padPhi);
+      varname = "pad";// + to_string(key);
+      cdbttree->SetIntValue(key,varname,padN);
+
+    }
+  }
+
+  std::cout<<"cdbttree->Commit();"<<std::endl;
+  cdbttree->Commit();
+  std::cout<<"cdbttree->Print();"<<std::endl;
+  //cdbttree->Print();
+  std::cout<<"cdbttree->WriteCDBTTree()"<<std::endl;
+  cdbttree->WriteCDBTTree();
+
+  std::cout<<"delete cdbttree;"<<std::endl;
+  delete cdbttree;
+  //delete M;
+  std::cout<<"gSystem->Exit(0);"<<std::endl;
+
+  gSystem->Exit(0);
+}
+

--- a/TPC/Mapping/README.md
+++ b/TPC/Mapping/README.md
@@ -1,0 +1,33 @@
+# TPC padplane mapping
+
+This repository contains macros to generate TPC padplane geometry
+
+## Reading maps from the padplane design
+
+ChannelMapping.ipynb provides functionality to generate CSV files containing mapping of the pads to the FEEs.
+
+Read files from Eagle drawings:
+```
+./PadPlane/AutoPad-R3-RevA.sch
+./PadPlane/AutoPad-R3-RevA.brd
+./PadPlane/AutoPad-R2-RevA-Pads.sch
+./PadPlane/AutoPad-R2-RevA-Pads.brd
+./PadPlane/AutoPad-R1-RevA.sch
+./PadPlane/AutoPad-R1-RevA.brd
+```
+
+Generated CSV files:
+```
+./PadPlane/AutoPad-R3-RevA.sch.ChannelMapping.csv
+./PadPlane/AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv
+./PadPlane/AutoPad-R1-RevA.sch.ChannelMapping.csv
+```
+
+## Creating CDBTTree
+
+CDBTTree-s are used to store detector data, in this case it is TPC padplane electronics to geometry.
+
+To generate CDBTTree from CSV files produced above, do:
+```
+root -l TestCDBTTreeTPC.C
+```


### PR DESCRIPTION
Adding MapCDBTTreeTPC.C and README.md

## Creating CDBTTree

CDBTTree-s are used to store detector data, in this case it is TPC padplane electronics to geometry.

To generate CDBTTree from CSV files produced above, do:
```
root -l TestCDBTTreeTPC.C
```